### PR TITLE
@Component spring beans are not scanned automatically when bundle gets installed

### DIFF
--- a/src/main/resources/META-INF/spring/application-context.xml
+++ b/src/main/resources/META-INF/spring/application-context.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/context
+http://www.springframework.org/schema/context/spring-context-3.0.xsd http://www.springframework.org/schema/util
+http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+
+	<context:component-scan base-package="nl.runnable.alfresco.examples" />
+
+</beans>


### PR DESCRIPTION
Hi,
great example. When I installed the bundle the classes annotated with @Component have never been loaded.
So I had to add META-INF/spring/application-context.xml for explicit component-scan declaration and now the example  WebScripts are shown and executable.
Maybe there's a simpler solution getting components scanned and loaded automatically.

environment: alfresco (4.2.0 community)
dynamic-extensions-for-alfresco (latest)

with kind regards
