### PR TITLE
Update field name to component ID to match delegate class

### DIFF
--- a/src/main/resources/META-INF/alfresco/workflows/ServiceTaskExample.bpmn20.xml
+++ b/src/main/resources/META-INF/alfresco/workflows/ServiceTaskExample.bpmn20.xml
@@ -9,13 +9,13 @@
         <endEvent id="theEnd"></endEvent>
         <serviceTask id="dynamicServiceTask" name="Dynamic Service Task" activiti:class="com.github.dynamicextensionsalfresco.workflow.activiti.DelegateTask">
             <extensionElements>
-                <activiti:field name="taskId">
+                <activiti:field name="componentId">
                     <activiti:string><![CDATA[example.dynamicextensions.testTask]]></activiti:string>
                 </activiti:field>
             </extensionElements>
         </serviceTask>
         <sequenceFlow id="flow4" sourceRef="start" targetRef="dynamicServiceTask"></sequenceFlow>
-        <userTask id="usertask1" name="User Task" activiti:assignee="administrator" activiti:formKey="wf:activitiReviewTask"></userTask>
+        <userTask id="usertask1" name="User Task" activiti:assignee="admin" activiti:formKey="wf:activitiReviewTask"></userTask>
         <sequenceFlow id="flow5" sourceRef="dynamicServiceTask" targetRef="usertask1"></sequenceFlow>
         <sequenceFlow id="flow6" sourceRef="usertask1" targetRef="theEnd"></sequenceFlow>
     </process>


### PR DESCRIPTION
This commit fixes a bug I ran into when testing the workflow example on the newest version of dynamic extensions.

You'll get this nice non-descript error if you have verbose enough debug logs:
```
04:22:20,329 DEBUG [org.activiti.engine.impl.interceptor.CommandContext] Error while closing command context
org.activiti.engine.ActivitiIllegalArgumentException: Field definition uses unexisting field 'taskId' on class com.github.dynamicextensionsalfresco.workflow.activiti.DelegateTask
```

